### PR TITLE
Output background noise value in DatasetGenerator

### DIFF
--- a/include/DatasetGenerator.h
+++ b/include/DatasetGenerator.h
@@ -39,36 +39,38 @@ class DatasetGenerator;
  * @struct ContinuousDataset
  * @brief A struct that contains a continuous dataset.
  *
- * This struct contains a continuous dataset. The dataset is composed of three
- * vectors: the samples vector, the ampltitudes vector, and the phases vector.
- * The samples vector contains the sample coordinate of the signal at a given
- * index. The amplitude vector contains the truth amplitude value at a given
- * index, and the phase vector contains the truth phase value at a given index.
+ * This struct contains a continuous dataset. The dataset is composed of the
+ * following vectors:
+ *   - time: the time coordinate of the signal at a given index;
+ *   - samples: the sample coordinate of the signal at a given index plus the noise;
+ *   - amplitudes: the truth amplitude value at a given index;
+ *   - phases: the truth phase value at a given index;
+ *   - noise: the background noise;
  */
 struct ContinuousDataset {
   std::vector<double> time; //!< The time series of the dataset
   std::vector<double> samples; //!< The samples of the dataset
   std::vector<double> amplitudes; //!< The amplitudes of the pulses in the dataset
   std::vector<double> phases; //!< The phases of the pulses in the dataset
+  std::vector<double> noise; //!< The background noise in the dataset
 };
 
 /**
  * @struct SlicedDataset
  * @brief A struct that contains a sliced dataset.
  *
- * This struct contains a sliced dataset. The dataset is composed of three
- * matrices: the samples matrix, the ampltitudes matrix, and the phases matrix.
+ * This struct contains a sliced dataset. The dataset is composed of the following
+ * matrices: time, samples, ampltitudes, phases, and noise.
  * Each matrix has a number of rows equal to the number of pulses in the
- * dataset, and a number of columns equal to the slice size. The samples matix
- * contains the sample coordinate of the signal at a given window index. The
- * amplitude vector contains the truth amplitude value at a given window index,
- * and the phase vector contains the truth phase value at a given window index.
- */
+ * dataset, and a number of columns equal to the slice size. Please, refer to the
+ * ContinuousDataset struct for more information about the dataset.
+ * */
 struct SlicedDataset {
   std::vector<std::vector<double>> time;
   std::vector<std::vector<double>> samples;
   std::vector<std::vector<double>> amplitudes;
   std::vector<std::vector<double>> phases;
+  std::vector<std::vector<double>> noise;
 };
 
 /**

--- a/lib/DatasetGenerator.cpp
+++ b/lib/DatasetGenerator.cpp
@@ -66,26 +66,30 @@ const SlicedDataset* DatasetGenerator::GenerateSlicedDataset(unsigned int nSlice
   std::vector<std::vector<double>> slicedSamples(nSlices);
   std::vector<std::vector<double>> slicedAmpltiudes(nSlices);
   std::vector<std::vector<double>> slicedPhases(nSlices);
+  std::vector<std::vector<double>> slicedNoise(nSlices);
 
   for (unsigned int i = 0; i < nSlices; i++) {
     std::vector<double> time(sliceSize);
     std::vector<double> samples(sliceSize);
     std::vector<double> amplitudes(sliceSize);
     std::vector<double> phases(sliceSize);
+    std::vector<double> noise(sliceSize);
     for (unsigned int j = 0; j < sliceSize; j++) {
       time[j] = continuousDataset->time[i * sliceSize + j];
       samples[j] = continuousDataset->samples[i * sliceSize + j];
       amplitudes[j] = continuousDataset->amplitudes[i * sliceSize + j];
       phases[j] = continuousDataset->phases[i * sliceSize + j];
+      noise[j] = continuousDataset->noise[i * sliceSize + j];
     }
     slicedTime[i] = time;
     slicedSamples[i] = samples;
     slicedAmpltiudes[i] = amplitudes;
     slicedPhases[i] = phases;
+    slicedNoise[i] = noise;
   }
 
   delete continuousDataset;
-  return new SlicedDataset { slicedTime, slicedSamples, slicedAmpltiudes, slicedPhases };
+  return new SlicedDataset { slicedTime, slicedSamples, slicedAmpltiudes, slicedPhases, slicedNoise };
 }
 
 const std::vector<AnalogPulse*> DatasetGenerator::GenerateEvents(unsigned int nEvents) const {
@@ -123,12 +127,15 @@ const ContinuousDataset* DatasetGenerator::SampleEvents(std::vector<AnalogPulse*
   std::vector<double> samples(nEvents, m_pulseGenerator->GetPedestal());
   std::vector<double> amplitudes(nEvents, 0);
   std::vector<double> phases(nEvents, 0);
+  std::vector<double> noise(nEvents, 0);
 
   for (unsigned int n = 0; n < nEvents; n++) {
     double currentTime = n * m_samplingRate;
+    double backgroundNoise = GenerateNoise();
 
     time[n] = currentTime;
-    samples[n] += GenerateNoise();
+    noise[n] = backgroundNoise;
+    samples[n] += backgroundNoise;
 
     auto pulse = pulses[n];
     if (!pulse) continue;
@@ -156,6 +163,7 @@ const ContinuousDataset* DatasetGenerator::SampleEvents(std::vector<AnalogPulse*
     samples = samples,
     amplitudes = amplitudes,
     phases = phases,
+    noise = noise,
   };
 }
 

--- a/python/tests/dataset_generator_unittest.py
+++ b/python/tests/dataset_generator_unittest.py
@@ -69,6 +69,7 @@ class DatasetGenerator(unittest.TestCase):
         self.assertEqual(dataset.samples.size(), n_events)
         self.assertEqual(dataset.amplitudes.size(), n_events)
         self.assertEqual(dataset.phases.size(), n_events)
+        self.assertEqual(dataset.noise.size(), n_events)
 
 
     def test_sliced_dataset(self):
@@ -92,6 +93,8 @@ class DatasetGenerator(unittest.TestCase):
         self.assertEqual(dataset.amplitudes[0].size(), slice_size)
         self.assertEqual(dataset.phases.size(), n_slices)
         self.assertEqual(dataset.phases[0].size(), slice_size)
+        self.assertEqual(dataset.noise.size(), n_slices)
+        self.assertEqual(dataset.noise[0].size(), slice_size)
 
 
 if __name__ == '__main__':

--- a/tests/dataset_generator_unittest.cpp
+++ b/tests/dataset_generator_unittest.cpp
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU General Public License along with
  * CPS. If not, see <https://www.gnu.org/licenses/>.
  */
+#include <iomanip>
 #include <gtest/gtest.h>
 #include "TextFilePulseShape.h"
 #include "PulseGenerator.h"
@@ -27,6 +28,24 @@
 #endif
 
 using namespace cps;
+
+void PrintDataset(const ContinuousDataset* dataset) {
+  std::cout <<
+    std::setw(15) << "time" <<
+    std::setw(15) << "sample" <<
+    std::setw(15) << "amplitude" <<
+    std::setw(15) << "phase" <<
+    std::setw(15) << "noise" << std::endl;
+
+  for (int i = 0; i < dataset->time.size(); i++) {
+    std::cout <<
+      std::setw(15) << dataset->time[i] <<
+      std::setw(15) << dataset->samples[i] <<
+      std::setw(15) << dataset->amplitudes[i] <<
+      std::setw(15) << dataset->phases[i] <<
+      std::setw(15) << dataset->noise[i] << std::endl;
+  }
+}
 
 TEST(DatasetGenerator, PulseGenerator) {
   DatasetGenerator datasetGenerator;
@@ -78,7 +97,7 @@ TEST(DatasetGenerator, GenerateContinuousDataset) {
   DatasetGenerator datasetGenerator = DatasetGenerator();
   datasetGenerator.SetSamplingRate(25.0);
   datasetGenerator.SetOccupancy(0.05);
-  datasetGenerator.SetNoiseParams(0, 0);
+  datasetGenerator.SetNoiseParams(0, 0.5);
   datasetGenerator.SetPulseGenerator(pulseGenerator);
 
   unsigned int nEvents = 100;
@@ -87,6 +106,9 @@ TEST(DatasetGenerator, GenerateContinuousDataset) {
   EXPECT_EQ(dataset->samples.size(), nEvents);
   EXPECT_EQ(dataset->amplitudes.size(), nEvents);
   EXPECT_EQ(dataset->phases.size(), nEvents);
+  EXPECT_EQ(dataset->noise.size(), nEvents);
+
+  PrintDataset(dataset);
 }
 
 TEST(DatasetGenerator, EventScheme) {
@@ -95,7 +117,7 @@ TEST(DatasetGenerator, EventScheme) {
   DatasetGenerator datasetGenerator = DatasetGenerator();
   datasetGenerator.SetSamplingRate(25.0);
   datasetGenerator.SetOccupancy(1.0);
-  datasetGenerator.SetNoiseParams(0, 0);
+  datasetGenerator.SetNoiseParams(0, 0.5);
   datasetGenerator.SetPulseGenerator(pulseGenerator);
   datasetGenerator.SetEventsScheme({ DatasetGenerator::AllowedEventsBlock(5), DatasetGenerator::NotAllowedEventsBlock(25) });
 
@@ -105,10 +127,9 @@ TEST(DatasetGenerator, EventScheme) {
   EXPECT_EQ(dataset->samples.size(), nEvents);
   EXPECT_EQ(dataset->amplitudes.size(), nEvents);
   EXPECT_EQ(dataset->phases.size(), nEvents);
+  EXPECT_EQ(dataset->noise.size(), nEvents);
 
-  for (int i = 0; i < nEvents; i++) {
-    std::cout << dataset->samples[i] << "\t" << dataset->amplitudes[i] << std::endl;
-  }
+  PrintDataset(dataset);
 }
 
 TEST(DatasetGenerator, GenerateSlicedDataset) {
@@ -131,4 +152,6 @@ TEST(DatasetGenerator, GenerateSlicedDataset) {
   EXPECT_EQ(dataset->amplitudes[0].size(), sliceSize);
   EXPECT_EQ(dataset->phases.size(), nSlices);
   EXPECT_EQ(dataset->phases[0].size(), sliceSize);
+  EXPECT_EQ(dataset->noise.size(), nSlices);
+  EXPECT_EQ(dataset->noise[0].size(), sliceSize);
 }


### PR DESCRIPTION
Now, it's possible to retrieve the background noise value for each sample through the `DatasetGenerator` class.

**C++ Usage**
```c++
auto dataset = datasetGenerator.GenerateContinuousDataset(nEvents);
auto noise =  dataset->noise;
```

**Python Usage**
```python
dataset = dataset_generator.generate_continuous_dataset(n_events)
noise = np.array(dataset.noise)
```

**Output histogram example:**
![image](https://github.com/ingoncalves/calorimetry-pulse-simulator/assets/5985312/6553cc3b-54b7-4e05-b803-d12c4281d42b)
